### PR TITLE
Fix 10: Generating database dumps without sanitizing data #10

### DIFF
--- a/cloud-teleport
+++ b/cloud-teleport
@@ -22,6 +22,15 @@ function teleport_scp()
 function dump_by_type()
 {
     local type=$1
+    case "$type" in
+      db) type="db -i"
+        ;;
+      code)
+        ;;
+      *) echo "Invalid type: specify code or db";
+         exit 1;
+        ;;
+    esac
     echo "Starting ${type} backup..."
     teleport_send_cmd "php bin/magento support:backup:${type};" && {
     dumpsDirectory="var/support/"


### PR DESCRIPTION
sanitizing adds option --skip-extended-insert and it leads to creating separate insert statements instead one multi-value insert statement. Which significantly decrease performance